### PR TITLE
Fix setting of title in GraphView constructor

### DIFF
--- a/src/com/jjoe64/graphview/GraphView.java
+++ b/src/com/jjoe64/graphview/GraphView.java
@@ -352,7 +352,7 @@ abstract public class GraphView extends LinearLayout {
 		setLayoutParams(new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
 
 		if (title == null)
-			title = "";
+			this.title = "";
 		else
 			this.title = title;
 


### PR DESCRIPTION
This was causing Eclipse to throw an error in the layout editor when no title was set.
