### PR TITLE
getViewPort function added

### DIFF
--- a/src/com/jjoe64/graphview/GraphView.java
+++ b/src/com/jjoe64/graphview/GraphView.java
@@ -690,7 +690,7 @@ abstract public class GraphView extends LinearLayout {
 	 * returns the size of the Viewport
 	 * 
 	 */
-	public double getViewPort(){
+	public double getViewportSize(){
 		return viewportSize;
 	}
 


### PR DESCRIPTION
I am developing the mHealthDroid: a framework for rapid development of mHealth applications in Android.  I am working with portable health devices and I wanted to use the real time visualization but I needed to know when I have as much samples as the viewport size. I needed to know it in order to use the appendData function properly. That is, if I have received less samples that the viewport size, the appendData should not scroll to the end, otherwise appenData should scroll to the end. Thus, I added the fuction getViewPort() to make this task possible.
