### PR TITLE
ensure that series created only if data array not empty #179

### DIFF
--- a/src/main/java/com/jjoe64/graphview/GraphViewSeries.java
+++ b/src/main/java/com/jjoe64/graphview/GraphViewSeries.java
@@ -133,7 +133,7 @@ public class GraphViewSeries {
 	 * @param maxDataCount if max data count is reached, the oldest data value will be lost
 	 */
 	public void appendData(GraphViewDataInterface value, boolean scrollToEnd, int maxDataCount) {
-        if (value.getX() < values[values.length-1].getX() && value.length > 0) {
+        if (values.length > 0 && value.getX() < values[values.length-1].getX()) {
             throw new IllegalArgumentException("new x-value must be greater then the last value. x-values has to be ordered in ASC.");
         }
 		synchronized (values) {


### PR DESCRIPTION
Fixed thE problem of creating series if the data array is empty, as described in issue 179
