### PR TITLE
create a “dotted” style for lineGraphView

### DIFF
--- a/src/main/java/com/jjoe64/graphview/GraphViewSeries.java
+++ b/src/main/java/com/jjoe64/graphview/GraphViewSeries.java
@@ -34,6 +34,7 @@ public class GraphViewSeries {
 		public int color = 0xff0077cc;
 		public int thickness = 3;
 		private ValueDependentColor valueDependentColor;
+		private int[] mDotted = new int[]{0, 0};
 
 		public GraphViewSeriesStyle() {
 			super();
@@ -56,6 +57,20 @@ public class GraphViewSeries {
 		public void setValueDependentColor(ValueDependentColor valueDependentColor) {
 			this.valueDependentColor = valueDependentColor;
 		}
+
+		/**
+		 * Dotted style need a path.
+		 * only possible in LineGraphView
+		 * @param dotLength
+		 * @param spacing
+		 */
+		public void setDotted(int dotLength, int spacing){
+			this.mDotted = new int[]{dotLength, spacing};
+		}
+
+		public int[] getDotted(){
+            return this.mDotted;
+        }
 	}
 
 	final String description;

--- a/src/main/java/com/jjoe64/graphview/LineGraphView.java
+++ b/src/main/java/com/jjoe64/graphview/LineGraphView.java
@@ -22,9 +22,11 @@ package com.jjoe64.graphview;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.DashPathEffect;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.util.AttributeSet;
+import android.view.View;
 
 import com.jjoe64.graphview.GraphViewSeries.GraphViewSeriesStyle;
 
@@ -65,6 +67,13 @@ public class LineGraphView extends GraphView {
 		paint.setStrokeWidth(style.thickness);
 		paint.setColor(style.color);
 
+		int[] dotStyle = style.getDotted();
+		if (dotStyle[0] != 0 && dotStyle[1] != 0) {
+			paint.setPathEffect(new DashPathEffect(new float[]{dotStyle[0], dotStyle[0] + dotStyle[1]}, 0));
+			if (android.os.Build.VERSION.SDK_INT >= 11) {
+				this.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+			}
+		}
 
 		Path bgPath = null;
 		if (drawBackground) {
@@ -120,6 +129,11 @@ public class LineGraphView extends GraphView {
 			bgPath.close();
 			canvas.drawPath(bgPath, paintBackground);
 		}
+
+        // restore the paint path effect
+        if (dotStyle[0] != 0 && dotStyle[1] != 0) {
+            paint.setPathEffect(null);
+        }
 	}
 
 	public int getBackgroundColor() {


### PR DESCRIPTION
Hi, 
For my own use, i needed to have dashed line graph. So i'm pull-requesting it.

To have a dotted line, you need to call the function `gvStyle.setDotted(int length, int space)` on a graphviewstyle element.

Technically, i need to activate hardware acceleration because `DashPathEffect/drawLine` function seems to require it (or is buggy) for recent Android version. The alternative of this would to draw linegraphview with a `canvas.drawPath` and not drawLine, but require a `STROKE` paint style, and can maybe introduce side effects bugs in the library.

There a lot of case that a dotted line can be usefull, like data projection or threshold type like stock value, or bank account value. Here some examples : 
![dotted_graph_1](https://cloud.githubusercontent.com/assets/1333761/3941983/ae6d258e-254d-11e4-98f4-1c346c0d2e97.jpg)
![dotted_graph_2](https://cloud.githubusercontent.com/assets/1333761/3941982/ae6b62a8-254d-11e4-8953-8bb93f38a98c.jpg)

