### PR TITLE
performance improve for LineGraphSeries

### DIFF
--- a/src/main/java/com/jjoe64/graphview/series/LineGraphSeries.java
+++ b/src/main/java/com/jjoe64/graphview/series/LineGraphSeries.java
@@ -100,11 +100,6 @@ public class LineGraphSeries<E extends DataPointInterface> extends BaseSeries<E>
     private Path mPathBackground;
 
     /**
-     * path to the line
-     */
-    private Path mPath;
-
-    /**
      * custom paint that can be used.
      * this will ignore the thickness and color styles.
      */
@@ -139,7 +134,6 @@ public class LineGraphSeries<E extends DataPointInterface> extends BaseSeries<E>
         mPaintBackground = new Paint();
 
         mPathBackground = new Path();
-        mPath = new Path();
     }
 
     /**
@@ -262,10 +256,7 @@ public class LineGraphSeries<E extends DataPointInterface> extends BaseSeries<E>
                 }
                 registerDataPoint(endX, endY, value);
 
-                mPath.reset();
-                mPath.moveTo(startX, startY);
-                mPath.lineTo(endX, endY);
-                canvas.drawPath(mPath, paint);
+                canvas.drawLine(startX, startY, endX, endY, paint);
                 if (mStyles.drawBackground) {
                     if (i==1) {
                         firstX = startX;


### PR DESCRIPTION
Using `canvas.drawLine(startX, startY, endX, endY, paint)` instead of `canvas.drawPath(mPath, paint)` (for single-line content) is faster, especially on slow devices.