### PR TITLE
fix issue on dotted graph dot still visible before Y axis when scroll…

### DIFF
--- a/src/main/java/com/jjoe64/graphview/series/PointsGraphSeries.java
+++ b/src/main/java/com/jjoe64/graphview/series/PointsGraphSeries.java
@@ -211,7 +211,11 @@ public class PointsGraphSeries<E extends DataPointInterface> extends BaseSeries<
             if (y > graphHeight) { // end top
                 overdraw = true;
             }
-
+            /* Fix a bug that continue to show the DOT after Y axis */
+            if(x < 0) {
+            	overdraw = true;
+            }
+            
             float endX = (float) x + (graphLeft + 1);
             float endY = (float) (graphTop - y) + graphHeight;
             registerDataPoint(endX, endY, value);


### PR DESCRIPTION
Hi Joe, was using your dotted graph with line graph. When scrolling to left, the dot keep appearing even after the Y axis. So the above code seems to help eliminate this issue.