### PR TITLE
Prevent infinite loop while human-rounding negative values

### DIFF
--- a/src/main/java/com/jjoe64/graphview/GridLabelRenderer.java
+++ b/src/main/java/com/jjoe64/graphview/GridLabelRenderer.java
@@ -1081,11 +1081,11 @@ public class GridLabelRenderer {
     protected double humanRound(double in, boolean roundAlwaysUp) {
         // round-up to 1-steps, 2-steps or 5-steps
         int ten = 0;
-        while (in >= 10d) {
+        while (Math.abs(in) >= 10d) {
             in /= 10d;
             ten++;
         }
-        while (in < 1d) {
+        while (Math.abs(in) < 1d) {
             in *= 10d;
             ten--;
         }


### PR DESCRIPTION
(I hope I understood the code well, at least it fixed the bug I had)
Changed `in < value` and `in > value` by `Math.abs(in) < value` and `Math.abs(in) > value`