### PR TITLE
Adding Support to LogarithmScale

### DIFF
--- a/src/main/java/com/jjoe64/graphview/Viewport.java
+++ b/src/main/java/com/jjoe64/graphview/Viewport.java
@@ -67,6 +67,11 @@ public class Viewport {
     protected boolean scalableY;
 
     /**
+     * flag whether the logarithmic scale scaling is activated
+     */
+    protected boolean logarithmicScale;
+
+    /**
      * minimal viewport used for scaling and scrolling.
      * this is used if the data that is available is
      * less then the viewport that we want to be able to display.
@@ -885,9 +890,10 @@ public class Viewport {
      * Make sure to set the y bounds to manual via
      * {@link #setYAxisBoundsManual(boolean)}
      * @param y max / highest value
+     * notice: if logarithmic scale is active, Math.log10 is applied
      */
     public void setMaxY(double y) {
-        mCurrentViewport.top = y;
+        mCurrentViewport.top = (logarithmicScale)?Math.floor(Math.log10(y)):y;
     }
 
     /**
@@ -1291,6 +1297,20 @@ public class Viewport {
             }
         }
         this.scalableY = scalableY;
+    }
+
+    /**
+     * activate or deactivate the logarithmic scaling functionallity.
+     * notice: sets the y axis bounds to manual
+     *
+     * @param logarithmicScale true to activate
+     */
+    public void setLogarithmicScale(boolean logarithmicScale) {
+        if (logarithmicScale) {
+            this.logarithmicScale = true;
+            setYAxisBoundsManual(true);
+        }
+        this.logarithmicScale = logarithmicScale;
     }
 
     /**

--- a/src/main/java/com/jjoe64/graphview/helper/LogarithmicAsYAxisLabelFormatter.java
+++ b/src/main/java/com/jjoe64/graphview/helper/LogarithmicAsYAxisLabelFormatter.java
@@ -1,0 +1,66 @@
+/**
+ * GraphView
+ * Copyright 2016 Jonas Gehring
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jjoe64.graphview.helper;
+
+import android.content.Context;
+
+import com.jjoe64.graphview.DefaultLabelFormatter;
+
+import java.text.DateFormat;
+import java.util.Calendar;
+
+/**
+ * Helper class to use date objects as x-values.
+ * This will use your own Date Format or by default
+ * the Android default date format to convert
+ * the x-values (that has to be millis from
+ * 01-01-1970) into a formatted date string.
+ *
+ * See the DateAsXAxis example in the GraphView-Demos project
+ * to see a working example.
+ *
+ * @author jjoe64
+ */
+public class LogarithmicAsYAxisLabelFormatter extends DefaultLabelFormatter {
+
+    /**
+     * create the formatter with the logarithmic scale for
+     * the y-values
+     *
+     * @param context the application context
+     */
+    public LogarithmicAsYAxisLabelFormatter(Context context) {
+    }
+
+    /**
+     * formats the y-values to logarithm values.
+     *
+     * @param value raw value
+     * @param isValueX true if it's a x value, otherwise false
+     * @return value converted to string
+     */
+    @Override
+    public String formatLabel(double value, boolean isValueX) {
+        if (isValueX) {
+            return super.formatLabel(value, isValueX);
+        } else {
+            String yValue=super.formatLabel(value, isValueX).replaceAll(",",".");
+            Float yLogValue = (float)Math.floor((Math.pow(10, Float.valueOf(yValue))));
+            return (value<=0)? "-∞":String.valueOf(yLogValue);
+        }
+    }
+}


### PR DESCRIPTION
//The user madatory must follow this order:
g.getViewport().setLogarithmicScale(true);
g.getViewport().setMaxY(200)//wanted value
*********************************************

//It has however when adding a datapoint to do something similar to:
new DataPoint(jx, (float) (Math.log10(val)));

//The option to logarithmformat was also add, to call it just do the following:
g.getGridLabelRenderer().setLabelFormatter(new LogarithmicAsYAxisLabelFormatter(getActivity()));