### PR TITLE
com.android.support:support-v4:27.1.1 requires SDK 14.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ android {
     buildToolsVersion '27.0.3'
 
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
com.android.support:support-v4:27.1.1 requires SDK 14.  GraphView indicates that it supports SDK 9.  This results in the following error:

```
> Manifest merger failed : uses-sdk:minSdkVersion 9 cannot be smaller than version 14 declared in library [com.android.support:support-v4:27.1.1] /home/travis/.gradle/caches/transforms-1/files-1.1/support-v4-27.1.1.aar/7af6945e1428faff7accdcdf1fa9678d/AndroidManifest.xml as the library might be using APIs not available in 9
  Suggestion: use a compatible library with a minSdk of at most 9,
     or increase this project's minSdk version to at least 14,
     or use tools:overrideLibrary="android.support.v4" to force usage (may lead to runtime failures)
```

This pull request bumps `minSdkVersion` to 14.