### PR TITLE
fixing duplicate label bug in x Axis when choosing to use custom labe…

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Oct 17 16:01:25 WEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/src/main/java/com/jjoe64/graphview/helper/StaticLabelsFormatter.java
+++ b/src/main/java/com/jjoe64/graphview/helper/StaticLabelsFormatter.java
@@ -174,21 +174,31 @@ public class StaticLabelsFormatter implements LabelFormatter {
      *                  false if it is a value for the y axis
      * @return
      */
+    static int oldIdx = -1;
+    String result = "";
     @Override
-    public String formatLabel(double value, boolean isValueX) {
+    synchronized public String formatLabel(double value, boolean isValueX) {
+
         if (isValueX && mHorizontalLabels != null) {
             double minX = mViewport.getMinX(false);
             double maxX = mViewport.getMaxX(false);
             double range = maxX - minX;
-            value = value-minX;
-            int idx = (int)((value/range) * (mHorizontalLabels.length-1));
-            return mHorizontalLabels[idx];
+            value = value - minX;
+            int idx = (int) ((value / range) * (mHorizontalLabels.length - 1));
+            // Log.e("StaticLabelsFormatter i= "+i, "formatLabel idx ="+idx+" " + mHorizontalLabels[i<mHorizontalLabels.length? i:mHorizontalLabels.length-1]);
+            if (oldIdx != idx)
+                result = mHorizontalLabels[idx];
+            else
+                result = mHorizontalLabels[idx + 1];
+            oldIdx = idx;
+            return result;
+
         } else if (!isValueX && mVerticalLabels != null) {
             double minY = mViewport.getMinY(false);
             double maxY = mViewport.getMaxY(false);
             double range = maxY - minY;
-            value = value-minY;
-            int idx = (int)((value/range) * (mVerticalLabels.length-1));
+            value = value - minY;
+            int idx = (int) ((value / range) * (mVerticalLabels.length - 1));
             return mVerticalLabels[idx];
         } else {
             return mDynamicLabelFormatter.formatLabel(value, isValueX);


### PR DESCRIPTION
in the idx expression (int idx = (int) ((value / range) * (mHorizontalLabels.length - 1));)
at least one time in execution i  got  i got the same value , so it add the same label to the xAxis ,
i resolved this issue by storing the previous idx and comparing it with the new one , if they are equals i aa 1 the the idx (idx=idx+1) . by that i prevent the duplicate labels bug in the x axis